### PR TITLE
Fix Elixir requirement to work with 1.1-dev

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Calendar.Mixfile do
     [app: :calendar,
      name: "Calendar",
      version: "0.8.1",
-     elixir: "~> 1.1.0 or ~> 1.0.0",
+     elixir: "~> 1.1.0-dev or ~> 1.0.0",
      package: package,
      description: description,
      deps: deps]


### PR DESCRIPTION
Since 1.1 isn't yet released this change was necessary to use it against the current Elixir master for me. Otherwise I got:

``` shell
% mix test
** (Mix) You're trying to run :calendar on Elixir v1.1.0-dev but it has declared in its mix.exs file it supports only Elixir ~> 1.1.0 or ~> 1.0.0
```
