### PR TITLE
Accept anything that contains time for Time.to_erl/1

### DIFF
--- a/lib/calendar/time.ex
+++ b/lib/calendar/time.ex
@@ -15,8 +15,9 @@ defmodule Calendar.Time do
   @doc """
   Takes a Time struct and returns an erlang style time tuple.
   """
-  def to_erl(%Calendar.Time{hour: hour, min: min, sec: sec}) do
-    {hour, min, sec}
+  def to_erl(time) do
+    time = time |> contained_time
+    {time.hour, time.min, time.sec}
   end
 
   @doc """

--- a/test/date_test.exs
+++ b/test/date_test.exs
@@ -1,6 +1,18 @@
+defmodule SomethingThatContainsDate do
+  defstruct []
+end
+
+defimpl Calendar.ContainsDate, for: SomethingThatContainsDate do
+  def date_struct(_), do: %Calendar.Date{year: 2015, month: 1, day: 1}
+end
+
 defmodule DateTest do
   use ExUnit.Case, async: true
   import Calendar.Date
   alias Calendar.NaiveDateTime
   doctest Calendar.Date
+
+  test "to_erl works for anything that contains a date" do
+    assert to_erl(%SomethingThatContainsDate{}) == {2015, 1, 1}
+  end
 end

--- a/test/date_time_test.exs
+++ b/test/date_time_test.exs
@@ -1,3 +1,11 @@
+defmodule SomethingThatContainsDateTime do
+  defstruct []
+end
+
+defimpl Calendar.ContainsDateTime, for: SomethingThatContainsDateTime do
+  def dt_struct(_), do: Calendar.DateTime.from_erl!({{2015, 1, 1}, {1, 1, 1}}, "UTC", 0)
+end
+
 defmodule DateTimeTest do
   use ExUnit.Case, async: true
   import Calendar.DateTime
@@ -72,5 +80,9 @@ defmodule DateTimeTest do
     assert tag == :ok
     {tag, _date_time} = from_erl({{2015, 7, 1}, {1, 59, 60}}, "Europe/Berlin")
     assert tag == :ok
+  end
+
+  test "to_erl works for anything that contains a date time" do
+    assert to_erl(%SomethingThatContainsDateTime{}) == {{2015, 1, 1}, {1, 1, 1}}
   end
 end

--- a/test/time_test.exs
+++ b/test/time_test.exs
@@ -1,6 +1,18 @@
+defmodule SomethingThatContainsTime do
+  defstruct []
+end
+
+defimpl Calendar.ContainsTime, for: SomethingThatContainsTime do
+  def time_struct(_), do: %Calendar.Time{hour: 1, min: 1, sec: 1, usec: 1}
+end
+
 defmodule TimeTest do
   use ExUnit.Case, async: true
   alias Calendar.Time
   import Calendar.Time
   doctest Calendar.Time
+
+  test "to_erl works for anything that contains a time" do
+    assert to_erl(%SomethingThatContainsTime{}) == {1, 1, 1}
+  end
 end


### PR DESCRIPTION
Add tests for Calendar.Time.to_erl/1, Calendar.Date.to_erl/1 and
Calendar.DateTime.to_erl/1

This fixes #11.
