### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Calendar
 
 [![Build
 Status](https://travis-ci.org/lau/calendar.svg?branch=master)](https://travis-ci.org/lau/calendar)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/lau/calendar.svg)](https://beta.hexfaktor.org/github/lau/calendar)
 [![Inline docs](http://inch-ci.org/github/lau/calendar.svg)](http://hexdocs.pm/calendar/)
 [![Hex Version](http://img.shields.io/hexpm/v/calendar.svg?style=flat)](https://hex.pm/packages/calendar)
 


### PR DESCRIPTION
Hi there,

I'm the maintainer of [Inch CI](https://inch-ci.org/) and this PR pitches my latest project for the Elixir community. That said, don't feel any obligation to accept the PR. You can't hurt my feelings by voicing your honest opinion about this idea!

Here comes the pitch:

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/lau/calendar.svg)](https://beta.hexfaktor.org/github/lau/calendar) [![Inline docs](http://inch-ci.org/github/lau/calendar.svg?branch=master)](http://inch-ci.org/github/lau/calendar)

You already know the Inch badge on the right: It shows you an analysis for your Elixir project's docs. The new badge does the same thing for your dependencies.

Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this.

Let me know what you think!
