### PR TITLE
add deprecation notice and link to add/2

### DIFF
--- a/lib/calendar/date_time.ex
+++ b/lib/calendar/date_time.ex
@@ -219,46 +219,7 @@ defmodule Calendar.DateTime do
   def subtract!(dt, seconds) , do: advance!(dt, -1 * seconds)
 
   @doc """
-  Takes a DateTime and an integer. Returns the `date_time` advanced by the number
-  of seconds found in the `seconds` argument.
-
-  If `seconds` is negative, the time is moved back.
-
-  The advancement is done in UTC. The datetime is converted to UTC, then
-  advanced, then converted back.
-
-  NOTE: this ignores leap seconds. The calculation is based on the (wrong) assumption that
-  there are no leap seconds.
-
-  ## Examples
-
-      # Advance 2 seconds
-      iex> from_erl!({{2014,10,2},{0,29,10}}, "America/New_York",123456) |> advance(2)
-      {:ok, %Calendar.DateTime{abbr: "EDT", day: 2, hour: 0, min: 29, month: 10,
-            sec: 12, std_off: 3600, timezone: "America/New_York", usec: 123456,
-            utc_off: -18000, year: 2014}}
-
-      # Advance 86400 seconds (one day)
-      iex> from_erl!({{2014,10,2},{0,29,10}}, "America/New_York",123456) |> advance(86400)
-      {:ok, %Calendar.DateTime{abbr: "EDT", day: 3, hour: 0, min: 29, month: 10,
-            sec: 10, std_off: 3600, timezone: "America/New_York", usec: 123456,
-            utc_off: -18000, year: 2014}}
-
-      # Go back 62 seconds
-      iex> from_erl!({{2014,10,2},{0,0,0}}, "America/New_York",123456) |> advance(-62)
-      {:ok, %Calendar.DateTime{abbr: "EDT", day: 1, hour: 23, min: 58, month: 10,
-            sec: 58, std_off: 3600, timezone: "America/New_York", usec: 123456, utc_off: -18000,
-            year: 2014}}
-
-      # Advance 10 seconds just before DST "spring forward" so we go from 1:59:59 to 3:00:09
-      iex> from_erl!({{2015,3,8},{1,59,59}}, "America/New_York",123456) |> advance(10)
-      {:ok, %Calendar.DateTime{abbr: "EDT", day: 8, hour: 3, min: 0, month: 3,
-            sec: 9, std_off: 3600, timezone: "America/New_York", usec: 123456,
-            utc_off: -18000, year: 2015}}
-
-      # Go back too far so that year would be before 0
-      iex> from_erl!({{2014,10,2},{0,0,0}}, "America/New_York",123456) |> advance(-999999999999)
-      {:error, :function_clause_error}
+  Deprecated version of `add/2`
   """
   def advance(date_time, seconds) do
     date_time = date_time |> contained_date_time


### PR DESCRIPTION
Addresses issue #25. The deprecation notice for advance!/2 seemed to be added already.   
