### PR TITLE
Parse microseconds in string input to `unix!`

### DIFF
--- a/lib/calendar/date_time/parse.ex
+++ b/lib/calendar/date_time/parse.ex
@@ -318,11 +318,11 @@ defmodule Calendar.DateTime.Parse do
   defp parse_fraction(""), do: {0, 0}
   # parse and return microseconds
   defp parse_fraction(string) do
-    usec = String.slice(string, 0..5)
-    |> String.ljust(6, ?0)
-    |> Integer.parse
-    |> elem(0)
-    {usec, min(String.length(string), 6)}
+    usec = String.slice(string, 0..6)   # Take 1 digit too many, so we can round
+      |> String.ljust(7, ?0)            # correctly if the fraction is long
+      |> Integer.parse
+      |> elem(0)
+    {round(usec/10), min(String.length(string), 6)}
   end
 
   defp parse_rfc3339_as_utc_with_offset(offset_in_secs, erl_date_time) do

--- a/lib/calendar/date_time/parse.ex
+++ b/lib/calendar/date_time/parse.ex
@@ -156,10 +156,8 @@ defmodule Calendar.DateTime.Parse do
   defp int_and_microsecond_for_float(float) do
     float_as_string = Float.to_string(float, [decimals: 6, compact: false])
     {int, frac} = Integer.parse(float_as_string)
-    {int, {parse_unix_fraction(frac), 6}}
+    {int, parse_fraction(frac)}
   end
-  # recieves eg. ".987654321" returns microseconds. eg. 987654
-  defp parse_unix_fraction(string), do: String.slice(string, 1..6) |> String.ljust(6, ?0) |> Integer.parse |> elem(0)
 
   @doc """
   Parse JavaScript style milliseconds since epoch.

--- a/lib/calendar/date_time/parse.ex
+++ b/lib/calendar/date_time/parse.ex
@@ -316,11 +316,11 @@ defmodule Calendar.DateTime.Parse do
   defp parse_fraction(""), do: {0, 0}
   # parse and return microseconds
   defp parse_fraction(string) do
-    usec = String.slice(string, 0..6)   # Take 1 digit too many, so we can round
-      |> String.ljust(7, ?0)            # correctly if the fraction is long
+    usec = String.slice(string, 0..5)
+      |> String.ljust(6, ?0)
       |> Integer.parse
       |> elem(0)
-    {round(usec/10), min(String.length(string), 6)}
+    {usec, min(String.length(string), 6)}
   end
 
   defp parse_rfc3339_as_utc_with_offset(offset_in_secs, erl_date_time) do

--- a/test/date_time_parse_test.exs
+++ b/test/date_time_parse_test.exs
@@ -5,7 +5,11 @@ defmodule DateTimeParseTest do
   doctest Parse
 
   test "microsecond precision is capped at 6" do
-    assert(unix!("1000000000.123456789").microsecond == {123457, 6})
+    assert(unix!("1000000000.123456789").microsecond == {123456, 6})
+  end
+
+  test "microsecond part is truncated, not rounded" do
+    assert(unix!("1000000000.999999999").microsecond == {999999, 6})
   end
 
   test "parsing floats always sets microsecond precision to 6" do

--- a/test/date_time_parse_test.exs
+++ b/test/date_time_parse_test.exs
@@ -5,6 +5,6 @@ defmodule DateTimeParseTest do
   doctest Parse
 
   test "microsecond precision is capped at 6" do
-    assert(unix!("1000000000.987654321").microsecond == {987654, 6})
+    assert(unix!("1000000000.123456789").microsecond == {123457, 6})
   end
 end

--- a/test/date_time_parse_test.exs
+++ b/test/date_time_parse_test.exs
@@ -7,4 +7,10 @@ defmodule DateTimeParseTest do
   test "microsecond precision is capped at 6" do
     assert(unix!("1000000000.123456789").microsecond == {123457, 6})
   end
+
+  test "parsing floats always sets microsecond precision to 6" do
+    assert(unix!(1.1).microsecond == {100_000, 6})
+    assert(unix!(1.123456789).microsecond == {123_457, 6})
+    assert(unix!(1.0).microsecond == {0, 6})
+  end
 end

--- a/test/date_time_parse_test.exs
+++ b/test/date_time_parse_test.exs
@@ -3,5 +3,8 @@ defmodule DateTimeParseTest do
   alias Calendar.DateTime.Parse
   import Parse
   doctest Parse
-end
 
+  test "microsecond precision is capped at 6" do
+    assert(unix!("1000000000.987654321").microsecond == {987654, 6})
+  end
+end


### PR DESCRIPTION
Vacation time got in the way, so I took a good while to get back to the microseconds parsing.
This closes #29 as far as I'm concerned.

There's a doctest showing that `unix!` can parse microsecond fractions in string input. I put an edge case for capping the precision in the test file because I didn't want to clutter the docs with low-value examples.

I found that `parse_fraction` would truncate rather than round input with a long fraction. This looked like a bug, so I fixed it. This private function seemed to cover what `parse_unix_fraction` did. Since floats are turned into a 6-digit string, precision will be 6, but that's a subtle effect of the implementation, so I added a test for this as well.
