### PR TITLE
Fix legacy iso_8601_basic format

### DIFF
--- a/lib/calendar/date_time/format.ex
+++ b/lib/calendar/date_time/format.ex
@@ -86,7 +86,7 @@ defmodule Calendar.DateTime.Format do
   @doc """
   Deprecated version of `iso8610_basic/1`
   """
-  def iso_8601_basic(dt), do: iso_8601_basic(dt)
+  def iso_8601_basic(dt), do: iso8601_basic(dt)
 
   @doc """
   Takes a DateTime.


### PR DESCRIPTION
The current implementation enters an infinite loop
