### PR TITLE
Fix Elixir 1.4 warning and update travis test combinations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,20 @@
 language: elixir
 
 elixir:
-  - 1.3.2
-  - 1.4.0-rc.1
+  - 1.3.4
+  - 1.4.0
 
 otp_release:
   - 18.2
-  - 19.1
+  - 19.2
 
 matrix:
   # We are only interested on the newest/oldest pair
   exclude:
-    - elixir: 1.4.0-rc.1
+    - elixir: 1.4.0
       otp_release: 18.2
-    - elixir: 1.3.2
-      otp_release: 19.1
+    - elixir: 1.3.4
+      otp_release: 19.2
 
 sudo: false
 

--- a/lib/calendar/date_time.ex
+++ b/lib/calendar/date_time.ex
@@ -63,7 +63,7 @@ defmodule Calendar.DateTime do
   @spec now(String.t) :: {:ok, DateTime.t} | :error
   def now(timezone) do
     try do
-      {now_utc_secs, microsecond} = now_utc |> gregorian_seconds_and_microsecond
+      {now_utc_secs, microsecond} = now_utc() |> gregorian_seconds_and_microsecond
       period_list = TimeZoneData.periods_for_time(timezone, now_utc_secs, :utc)
       period = hd period_list
       {:ok, now_utc_secs + period.utc_off + period.std_off


### PR DESCRIPTION
Added a fix for missing parentheses and updated travis to test the latest Elixir/Erlang combination for (1.4.0/19.2) and (1.3.4/18.2).