### PR TITLE
Update mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Calendar.Mixfile do
     [app: :calendar,
      name: "Calendar",
      version: "0.17.2",
-     elixir: "~> 1.4.0 or ~> 1.4.0-dev or ~> 1.3.0 or ~> 1.3.0-rc.1",
+     elixir: "~> 1.3",
      consolidate_protocols: false,
      package: package(),
      description: description(),


### PR DESCRIPTION
==> calendar

warning: the dependency :calendar requires Elixir "~> 1.4.0 or ~> 1.4.0-dev or ~> 1.3.0 or ~> 1.3.0-rc.1" but you are running on v1.5.0-rc.0

@lau please take a look, thanks!