### PR TITLE
Added time_format translations

### DIFF
--- a/lib/calendar/strftime.ex
+++ b/lib/calendar/strftime.ex
@@ -86,7 +86,7 @@ defmodule Calendar.Strftime do
   | %R               | Time in 24 hour notation excluding seconds. Equivalent of %H:%M.| _19:25_                        |           |         ✓ |         |
   | %T               | Time in 24 hour notation. Equivalent of %H:%M:%S.               | _19:25:41_                     |           |         ✓ |         |
   | %F               | Date in ISO 8601 format. Equivalent of %Y-%m-%d.                | _2015-02-05_                   |         ✓ |           |         |
-  | %xx              | Time in in format _for provided language_                       | _7:25 PM_                      |           |         ✓ |         |
+  | %X               | Time in in format _for provided language_                       | _7:25 PM_                      |           |         ✓ |         |
   | %x               | Date in in format _for provided language_                       | _05/02/2015_                   |         ✓ |           |         |
   | %c               | Date and time in format _for provided language_                 | _Wed Jan 13 11:34:10 2016_     |         ✓ |         ✓ |         |
   | %v               | VMS date. Equivalent of %e-%b-%Y.                               | _5-Feb-2015_                   |         ✓ |           |         |
@@ -163,7 +163,7 @@ defmodule Calendar.Strftime do
   defp string_for_conv_spec(dt, :Z, _) do "#{dt.zone_abbr}" end
 
   defp string_for_conv_spec(dt, :x, lang), do: strftime! dt, date_format_for_lang(lang), lang
-  defp string_for_conv_spec(dt, :xx, lang), do: strftime! dt, time_format_for_lang(lang), lang
+  defp string_for_conv_spec(dt, :X, lang), do: strftime! dt, time_format_for_lang(lang), lang
   defp string_for_conv_spec(dt, :c, lang), do: strftime! dt, date_time_format_for_lang(lang), lang
 
   defp micro_seconds(dt) do

--- a/lib/calendar/strftime.ex
+++ b/lib/calendar/strftime.ex
@@ -86,7 +86,7 @@ defmodule Calendar.Strftime do
   | %R               | Time in 24 hour notation excluding seconds. Equivalent of %H:%M.| _19:25_                        |           |         ✓ |         |
   | %T               | Time in 24 hour notation. Equivalent of %H:%M:%S.               | _19:25:41_                     |           |         ✓ |         |
   | %F               | Date in ISO 8601 format. Equivalent of %Y-%m-%d.                | _2015-02-05_                   |         ✓ |           |         |
-  | %y               | Time in in format _for provided language_                       | _7:25 PM_                   |         ✓ |           |         |
+  | %xx              | Time in in format _for provided language_                       | _7:25 PM_                      |           |         ✓ |         |
   | %x               | Date in in format _for provided language_                       | _05/02/2015_                   |         ✓ |           |         |
   | %c               | Date and time in format _for provided language_                 | _Wed Jan 13 11:34:10 2016_     |         ✓ |         ✓ |         |
   | %v               | VMS date. Equivalent of %e-%b-%Y.                               | _5-Feb-2015_                   |         ✓ |           |         |
@@ -163,7 +163,7 @@ defmodule Calendar.Strftime do
   defp string_for_conv_spec(dt, :Z, _) do "#{dt.zone_abbr}" end
 
   defp string_for_conv_spec(dt, :x, lang), do: strftime! dt, date_format_for_lang(lang), lang
-  defp string_for_conv_spec(dt, :y, lang), do: strftime! dt, time_format_for_lang(lang), lang
+  defp string_for_conv_spec(dt, :xx, lang), do: strftime! dt, time_format_for_lang(lang), lang
   defp string_for_conv_spec(dt, :c, lang), do: strftime! dt, date_time_format_for_lang(lang), lang
 
   defp micro_seconds(dt) do

--- a/lib/calendar/strftime.ex
+++ b/lib/calendar/strftime.ex
@@ -86,6 +86,7 @@ defmodule Calendar.Strftime do
   | %R               | Time in 24 hour notation excluding seconds. Equivalent of %H:%M.| _19:25_                        |           |         ✓ |         |
   | %T               | Time in 24 hour notation. Equivalent of %H:%M:%S.               | _19:25:41_                     |           |         ✓ |         |
   | %F               | Date in ISO 8601 format. Equivalent of %Y-%m-%d.                | _2015-02-05_                   |         ✓ |           |         |
+  | %y               | Time in in format _for provided language_                       | _7:25 PM_                   |         ✓ |           |         |
   | %x               | Date in in format _for provided language_                       | _05/02/2015_                   |         ✓ |           |         |
   | %c               | Date and time in format _for provided language_                 | _Wed Jan 13 11:34:10 2016_     |         ✓ |         ✓ |         |
   | %v               | VMS date. Equivalent of %e-%b-%Y.                               | _5-Feb-2015_                   |         ✓ |           |         |
@@ -162,7 +163,7 @@ defmodule Calendar.Strftime do
   defp string_for_conv_spec(dt, :Z, _) do "#{dt.zone_abbr}" end
 
   defp string_for_conv_spec(dt, :x, lang), do: strftime! dt, date_format_for_lang(lang), lang
-  defp string_for_conv_spec(dt, :X, lang), do: strftime! dt, time_format_for_lang(lang), lang
+  defp string_for_conv_spec(dt, :y, lang), do: strftime! dt, time_format_for_lang(lang), lang
   defp string_for_conv_spec(dt, :c, lang), do: strftime! dt, date_time_format_for_lang(lang), lang
 
   defp micro_seconds(dt) do

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Calendar.Mixfile do
 
   def deps do
     [
-      {:tzdata, "~> 0.5.8 or ~> 0.1.201603"},
+      {:tzdata, "~> 0.5.8 or ~> 0.1.201603", override: true},
       {:ex_doc, "~> 0.11", only: :dev},
       {:inch_ex, only: :docs},
      ]

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Calendar.Mixfile do
 
   def deps do
     [
-      {:tzdata, "~> 0.5.8 or ~> 0.1.201603", override: true},
+      {:tzdata, "~> 1.1", override: true},
       {:ex_doc, "~> 0.11", only: :dev},
       {:inch_ex, only: :docs},
      ]


### PR DESCRIPTION
Support for translation only time part of a datetime.

Also a PR to calendar_translations.

https://github.com/padde/calendar_translations/pull/7